### PR TITLE
Adapt script to allow the use of numbers for is_public value

### DIFF
--- a/check_process
+++ b/check_process
@@ -6,7 +6,8 @@
 		path="/path"	(PATH)
 		admin="john"	(USER)
 		language="fr"
-		is_public="Yes"	(PUBLIC|public=Yes|private=No)
+#		is_public="Yes"	(PUBLIC|public=Yes|private=No)
+		is_public=1	(PUBLIC|public=1|private=0)
 		password="pass"	(PASSWORD)
 		port="666"	(PORT)
 	; Checks

--- a/sub_scripts/testing_process.sh
+++ b/sub_scripts/testing_process.sh
@@ -472,10 +472,10 @@ CHECK_PUBLIC_PRIVATE () {
 	MANIFEST_ARGS_MOD=$(echo $MANIFEST_ARGS_MOD | sed "s/$MANIFEST_PASSWORD=[a-Z$]*\&/$MANIFEST_PASSWORD=$PASSWORD_TEST\&/")
 	# Choix public/privé
 	if [ "$1" == "private" ]; then
-		MANIFEST_ARGS_MOD=$(echo $MANIFEST_ARGS_MOD | sed "s/$MANIFEST_PUBLIC=[a-Z]*\&/$MANIFEST_PUBLIC=$MANIFEST_PUBLIC_private\&/")
+		MANIFEST_ARGS_MOD=$(echo $MANIFEST_ARGS_MOD | sed "s/$MANIFEST_PUBLIC=[a-Z0-9]*\&/$MANIFEST_PUBLIC=$MANIFEST_PUBLIC_private\&/")
 	fi
 	if [ "$1" == "public" ]; then
-		MANIFEST_ARGS_MOD=$(echo $MANIFEST_ARGS_MOD | sed "s/$MANIFEST_PUBLIC=[a-Z]*\&/$MANIFEST_PUBLIC=$MANIFEST_PUBLIC_public\&/")
+		MANIFEST_ARGS_MOD=$(echo $MANIFEST_ARGS_MOD | sed "s/$MANIFEST_PUBLIC=[a-Z0-9]*\&/$MANIFEST_PUBLIC=$MANIFEST_PUBLIC_public\&/")
 	fi
 	if [ "$GLOBAL_CHECK_ROOT" -eq 1 ]; then	# Utilise une install root, si elle a fonctionné
 		MANIFEST_ARGS_MOD=$(echo $MANIFEST_ARGS_MOD | sed "s@$MANIFEST_PATH=[a-Z/$]*\&@$MANIFEST_PATH=/\&@")


### PR DESCRIPTION
Adapt sample to latest Yunohost example: is_public is now a boolean.
As many packages still use a string format, leave the previous is_public specification as a comment.

