### PR TITLE
Deux points bloquants sur l'installation de container de test

### DIFF
--- a/sub_scripts/lxc_build.sh
+++ b/sub_scripts/lxc_build.sh
@@ -83,7 +83,7 @@ echo -e "\e[1m> Update et install aptitude sudo git\e[0m" | tee -a "$LOG_BUILD_L
 sudo lxc-attach -n $LXC_NAME -- apt-get update
 sudo lxc-attach -n $LXC_NAME -- apt-get install -y aptitude sudo git
 echo -e "\e[1m> Installation des paquets standard et ssh-server\e[0m" | tee -a "$LOG_BUILD_LXC"
-sudo lxc-attach -n $LXC_NAME -- aptitude install -y ~pstandard ~prequired ~pimportant task-ssh-server
+sudo lxc-attach -n $LXC_NAME -- apt-get install -y ~pstandard ~prequired ~pimportant task-ssh-server
 
 echo -e "\e[1m> Renseigne /etc/hosts sur l'invité\e[0m" | tee -a "$LOG_BUILD_LXC"
 echo "127.0.0.1 $LXC_NAME" | sudo tee -a /var/lib/lxc/$LXC_NAME/rootfs/etc/hosts >> "$LOG_BUILD_LXC" 2>&1

--- a/sub_scripts/lxc_build.sh
+++ b/sub_scripts/lxc_build.sh
@@ -30,12 +30,12 @@ echo -e "\e[1m> Update et install lxc lxctl\e[0m" | tee "$LOG_BUILD_LXC"
 sudo apt-get update >> "$LOG_BUILD_LXC" 2>&1
 sudo apt-get install -y lxc lxctl debootstrap bridge-utils >> "$LOG_BUILD_LXC" 2>&1
 
-os_name=$(sed -n -e '/PRETTY_NAME/ s/^.*=\|"\| .*//gp' /etc/os-release);
-if [ os_name == "Ubuntu" ]
+os_name=$(lsb_release -i | awk '{ print $NF }');
+if [ $os_name == "Ubuntu" ]
 then
 	sudo apt-get install -y lxc-templates >> "$LOG_BUILD_LXC" 2>&1
 fi
-if [ os_name == "Debian" ]
+if [ $os_name == "Debian" ]
 then
 	echo -e "\e[1m> On configure le bridge de LXC sur Debian\e[0m" | tee "$LOG_BUILD_LXC"
 	sudo sed -i 's/^USE_LXC_BRIDGE="true"$/USE_LXC_BRIDGE="false"/' /etc/default/lxc-net >> "$LOG_BUILD_LXC" 2>&1

--- a/sub_scripts/lxc_build.sh
+++ b/sub_scripts/lxc_build.sh
@@ -28,7 +28,7 @@ echo -e "# interface réseau principale de l'hôte\niface=$main_iface\n" > "$scr
 
 echo -e "\e[1m> Update et install lxc lxctl\e[0m" | tee "$LOG_BUILD_LXC"
 sudo apt-get update >> "$LOG_BUILD_LXC" 2>&1
-sudo apt-get install -y lxc lxctl >> "$LOG_BUILD_LXC" 2>&1
+sudo apt-get install -y lxc lxctl lxc-templates debootstrap >> "$LOG_BUILD_LXC" 2>&1
 
 sudo mkdir -p /var/lib/lxcsnaps	# Créer le dossier lxcsnaps, pour s'assurer que lxc utilisera ce dossier, même avec lxc 2.
 

--- a/sub_scripts/lxc_build.sh
+++ b/sub_scripts/lxc_build.sh
@@ -89,7 +89,7 @@ echo -e "\e[1m> Update et install aptitude sudo git\e[0m" | tee -a "$LOG_BUILD_L
 sudo lxc-attach -n $LXC_NAME -- apt-get update
 sudo lxc-attach -n $LXC_NAME -- apt-get install -y aptitude sudo git
 echo -e "\e[1m> Installation des paquets standard et ssh-server\e[0m" | tee -a "$LOG_BUILD_LXC"
-sudo lxc-attach -n $LXC_NAME -- apt-get install -y ~pstandard ~prequired ~pimportant task-ssh-server
+sudo lxc-attach -n $LXC_NAME -- aptitude install -y ~pstandard ~prequired ~pimportant task-ssh-server
 
 echo -e "\e[1m> Renseigne /etc/hosts sur l'invité\e[0m" | tee -a "$LOG_BUILD_LXC"
 echo "127.0.0.1 $LXC_NAME" | sudo tee -a /var/lib/lxc/$LXC_NAME/rootfs/etc/hosts >> "$LOG_BUILD_LXC" 2>&1

--- a/sub_scripts/lxc_build.sh
+++ b/sub_scripts/lxc_build.sh
@@ -28,7 +28,13 @@ echo -e "# interface réseau principale de l'hôte\niface=$main_iface\n" > "$scr
 
 echo -e "\e[1m> Update et install lxc lxctl\e[0m" | tee "$LOG_BUILD_LXC"
 sudo apt-get update >> "$LOG_BUILD_LXC" 2>&1
-sudo apt-get install -y lxc lxctl lxc-templates debootstrap >> "$LOG_BUILD_LXC" 2>&1
+sudo apt-get install -y lxc lxctl >> "$LOG_BUILD_LXC" 2>&1
+
+os_name=$(sed -n -e '/PRETTY_NAME/ s/^.*=\|"\| .*//gp' /etc/os-release);
+if [ os_name == "Ubuntu" ]
+then
+	sudo apt-get install -y lxc-templates debootstrap >> "$LOG_BUILD_LXC" 2>&1
+fi
 
 sudo mkdir -p /var/lib/lxcsnaps	# Créer le dossier lxcsnaps, pour s'assurer que lxc utilisera ce dossier, même avec lxc 2.
 

--- a/sub_scripts/lxc_build.sh
+++ b/sub_scripts/lxc_build.sh
@@ -76,6 +76,9 @@ sudo lxc-start -n $LXC_NAME -d --logfile "$script_dir/lxc_boot.log" >> "$LOG_BUI
 sleep 3
 sudo lxc-ls -f >> "$LOG_BUILD_LXC" 2>&1
 
+echo -e "\e[1m> On lance l'interface réseau\e[0m" | tee -a "$LOG_BUILD_LXC"
+sudo lxc-attach -n $LXC_NAME -- /etc/init.d/networking start
+
 echo -e "\e[1m> Update et install aptitude sudo git\e[0m" | tee -a "$LOG_BUILD_LXC"
 sudo lxc-attach -n $LXC_NAME -- apt-get update
 sudo lxc-attach -n $LXC_NAME -- apt-get install -y aptitude sudo git

--- a/sub_scripts/lxc_build.sh
+++ b/sub_scripts/lxc_build.sh
@@ -70,8 +70,8 @@ sudo ifup $LXC_BRIDGE --interfaces=/etc/network/interfaces.d/$LXC_BRIDGE >> "$LO
 echo -e "\e[1m> Configuration réseau du conteneur\e[0m" | tee -a "$LOG_BUILD_LXC"
 sudo sed -i "s/^lxc.network.type = empty$/lxc.network.type = veth\nlxc.network.flags = up\nlxc.network.link = $LXC_BRIDGE\nlxc.network.name = eth0\nlxc.network.hwaddr = 00:FF:AA:00:00:01/" /var/lib/lxc/$LXC_NAME/config >> "$LOG_BUILD_LXC" 2>&1
 
-# echo -e "\e[1m> Configuration réseau de la machine virtualisée\e[0m" | tee -a "$LOG_BUILD_LXC"
-# sudo sed -i "s@iface eth0 inet dhcp@iface eth0 inet static\n\taddress $PLAGE_IP.2/24\n\tgateway $PLAGE_IP.1@" /var/lib/lxc/$LXC_NAME/rootfs/etc/network/interfaces >> "$LOG_BUILD_LXC" 2>&1
+echo -e "\e[1m> Configuration réseau de la machine virtualisée\e[0m" | tee -a "$LOG_BUILD_LXC"
+sudo sed -i "s@iface eth0 inet dhcp@iface eth0 inet static\n\taddress $PLAGE_IP.2/24\n\tgateway $PLAGE_IP.1@" /var/lib/lxc/$LXC_NAME/rootfs/etc/network/interfaces >> "$LOG_BUILD_LXC" 2>&1
 
 echo -e "\e[1m> Configure le parefeu\e[0m" | tee -a "$LOG_BUILD_LXC"
 sudo iptables -A FORWARD -i $LXC_BRIDGE -o $main_iface -j ACCEPT >> "$LOG_BUILD_LXC" 2>&1
@@ -85,9 +85,6 @@ sudo lxc-ls -f >> "$LOG_BUILD_LXC" 2>&1
 
 echo -e "\e[1m> On lance l'interface réseau\e[0m" | tee -a "$LOG_BUILD_LXC"
 sudo lxc-attach -n $LXC_NAME -- /etc/init.d/networking start
-
-echo -e "\e[1m> On récupére l'ip du container\e[0m" | tee -a "$LOG_BUILD_LXC"
-IP_CONTAINER=$(sudo lxc-attach -n $LXC_NAME -- ip addr | grep 'state UP' -A2 | tail -n1 | awk '{print $2}' | cut -f1 -d'/')
 
 echo -e "\e[1m> Update et install aptitude sudo git\e[0m" | tee -a "$LOG_BUILD_LXC"
 sudo lxc-attach -n $LXC_NAME -- apt-get update
@@ -117,7 +114,7 @@ sudo lxc-attach -n $LXC_NAME -- chown pchecker: -R /home/pchecker/.ssh >> "$LOG_
 echo | tee -a $HOME/.ssh/config <<EOF >> "$LOG_BUILD_LXC" 2>&1
 # ssh $LXC_NAME
 Host $LXC_NAME
-Hostname $IP_CONTAINER
+Hostname $PLAGE_IP.2
 User pchecker
 IdentityFile $HOME/.ssh/$LXC_NAME
 EOF


### PR DESCRIPTION
J'apporte deux modifications qui m'aide à lancer correctement l'installation d'un container de test sur Linux/Mint

- Sur une distribution linux/Mint, lxc-templates doit être installé pour profiter des templates proposé par LXC, debootstrap n'est pas installé sur cette distribution par défaut.

- Lors de la création du container de test, l'interface réseau ne se lance pas. Je propose d'executer la commande qui va bien pour lancer le réseau.