### PR TITLE
Add ressource checks

### DIFF
--- a/sub_scripts/testing_process.sh
+++ b/sub_scripts/testing_process.sh
@@ -370,7 +370,7 @@ CHECK_URL_RESSOURCES()
 		rm "$RESULTS/portal"
 	fi
 
-	wc -l "$RESULTS"/*
+	wc -l "$RESULTS"/* | sed "s|$RESULTS||"
 	rm "$URLS_TO_TEST"
 	rm -rf "$RESULTS"
 }

--- a/sub_scripts/testing_process.sh
+++ b/sub_scripts/testing_process.sh
@@ -273,7 +273,10 @@ CHECK_URL () {
 					echo -e "\e[0m"
 
 				# Test http status of ressources files
-				CHECK_URL_RESSOURCES
+				if [[ $curl_error -eq 0 ]]
+				then
+					CHECK_URL_RESSOURCES
+				fi
 
 				fi
 			fi


### PR DESCRIPTION
When packaging an application, the package_checker can tell installation is successful, while important resources are missing, like JavaScript or CSS files.

If those files are missing, it probably means there is a path issue and the installation isn't full successful.
Note this patch was tested for locale resources, I don't know how it behaves with external resources (mostly CDN).

It surely needs more testing!

Double slash URL is not replaced, as it can exist on purpose... It is named "Protocol-relative URLs" https://en.wikipedia.org/wiki/URL#prurl