### PR TITLE
lxc_build: install ping in container

### DIFF
--- a/sub_scripts/lxc_build.sh
+++ b/sub_scripts/lxc_build.sh
@@ -129,9 +129,9 @@ sudo lxc-start -n $LXC_NAME -d --logfile "$script_dir/lxc_boot.log" >> "$LOG_BUI
 sleep 3
 sudo lxc-ls -f >> "$LOG_BUILD_LXC" 2>&1
 
-echo -e "\e[1m> Update et install aptitude sudo git\e[0m" | tee -a "$LOG_BUILD_LXC"
+echo -e "\e[1m> Update et install aptitude sudo git ping\e[0m" | tee -a "$LOG_BUILD_LXC"
 sudo lxc-attach -n $LXC_NAME -- apt-get update
-sudo lxc-attach -n $LXC_NAME -- apt-get install -y aptitude sudo git ssh openssh-server
+sudo lxc-attach -n $LXC_NAME -- apt-get install -y aptitude sudo git ssh openssh-server iputils-ping
 echo -e "\e[1m> Installation des paquets standard et ssh-server\e[0m" | tee -a "$LOG_BUILD_LXC"
 sudo lxc-attach -n $LXC_NAME -- aptitude install -y ~pstandard ~prequired ~pimportant
 


### PR DESCRIPTION
`ping` is required by `lxc_check` to test for internet connectivity. However it may not be installed by default on the LXC container. This commit ensures the `ping` command will be available inside the container.