### PR TITLE
testing_process: better explain why public/private test fails

### DIFF
--- a/sub_scripts/testing_process.sh
+++ b/sub_scripts/testing_process.sh
@@ -664,12 +664,14 @@ CHECK_PUBLIC_PRIVATE () {
 		then
 			# In private mode, if curl doesn't fell on the ynh portal, it's a fail.
 			if [ $yuno_portal -eq 0 ]; then
+				ECHO_FORMAT "App is not private: it should redirect to the Yunohost portal, but is publicly accessible instead\n" "lyellow" clog
 				yunohost_result=1
 			fi
 		elif [ "$install_type" = "public" ]
 		then
 			# In public mode, if curl fell on the ynh portal, it's a fail.
 			if [ $yuno_portal -eq 1 ]; then
+				ECHO_FORMAT "App page is not public: it should be publicly accessible, but redirects to the Yunohost portal instead\n" "lyellow" clog
 				yunohost_result=1
 			fi
 		fi


### PR DESCRIPTION
Currently, when an app fails the `public` or `private` test, only a "Test failed!" message is displayed. The root cause of the failure is missing – which leaves us wondering whether something went wrong during the installation itself, or what exactly happened during the privacy check.

This PR adds a warning about the cause of the failure, which should make these tests easier to understand and to fix.