### PR TITLE
launcher: fix creation of snap2

### DIFF
--- a/sub_scripts/launcher.sh
+++ b/sub_scripts/launcher.sh
@@ -84,7 +84,7 @@ create_temp_backup () {
 
 		# lxc always creates the first snapshot it can creates.
 		# So if snap1 doesn't exist and you try to create snap2, it will be named snap1.
-		if [ "$snap_number" == "2" ] && [ ! -e "$snapshot_path/snap1" ]
+		if [ "$snap_number" == "2" ] && [ ! -e "$snapshot_path/snap2" ]
 		then
 			# Rename snap1 to snap2
 			sudo mv "$snapshot_path/snap1" "$snapshot_path/snap2"

--- a/sub_scripts/launcher.sh
+++ b/sub_scripts/launcher.sh
@@ -78,7 +78,7 @@ create_temp_backup () {
 	# Check if the snapshot already exist
 	if [ ! -e "$snapshot_path/snap$snap_number" ]
 	then
-		echo "snap$snap_number doesn't exist, its first creation can be take a little while." >&2
+		echo "snap$snap_number doesn't exist, its first creation can takes a little while." >&2
 		# Create the snapshot.
 		sudo lxc-snapshot --name $lxc_name >> "$test_result" 2>&1
 


### PR DESCRIPTION
When attempting to create snap2, if snap1 doesn't exist, `lxc-snapshot` will create a snapshot named `snap1` (instead of `snap2`). In this case we need to rename snap1 into snap2.

However the condition check is wrong: after creating the snapshot, snap1 will *always* exist – even if it didn't before. Thus the renaming never happens.

Fix the issue by detecting the absence of snap2 (rather than snap1).