### PR TITLE
Add support for aarch64

### DIFF
--- a/sub_scripts/launcher.sh
+++ b/sub_scripts/launcher.sh
@@ -179,7 +179,11 @@ LXC_START () {
 			sleep 1
 		done
 		echo ""
-		sleep 30
+		if [ "$(uname -m)" == "aarch64" ]
+		then
+            sleep 30
+		fi
+		
 		local failstart=0
 		# Check if the container is running
 		if ! is_lxc_running; then

--- a/sub_scripts/launcher.sh
+++ b/sub_scripts/launcher.sh
@@ -181,7 +181,7 @@ LXC_START () {
 		echo ""
 		if [ "$(uname -m)" == "aarch64" ]
 		then
-            sleep 30
+			sleep 30
 		fi
 		
 		local failstart=0

--- a/sub_scripts/lxc_build.sh
+++ b/sub_scripts/lxc_build.sh
@@ -88,13 +88,13 @@ then	# Si le conteneur existe déjà
 fi
 
 echo -e "\e[1m> Création d'une machine debian $DISTRIB minimaliste.\e[0m" | tee -a "$LOG_BUILD_LXC"
-uname=$(uname -m)
-if [[ $uname =~ aarch64 ]]
+if [ "$(uname -m)" == "aarch64" ]
 then
-        sudo lxc-create -n $LXC_NAME -t debian -- -r $DISTRIB  --arch=arm64 >> "$LOG_BUILD_LXC" 2>&1
+        arch_arg="--arch=arm64"
 else
-        sudo lxc-create -n $LXC_NAME -t debian -- -r $DISTRIB >> "$LOG_BUILD_LXC" 2>&1
+        arch_arg=""
 fi
+sudo lxc-create -n $LXC_NAME -t debian -- -r $DISTRIB $arch_arg >> "$LOG_BUILD_LXC" 2>&1
 
 echo -e "\e[1m> Autoriser l'ip forwarding, pour router vers la machine virtuelle.\e[0m" | tee -a "$LOG_BUILD_LXC"
 echo "net.ipv4.ip_forward=1" | sudo tee /etc/sysctl.d/lxc_pchecker.conf >> "$LOG_BUILD_LXC" 2>&1

--- a/sub_scripts/lxc_build.sh
+++ b/sub_scripts/lxc_build.sh
@@ -88,7 +88,13 @@ then	# Si le conteneur existe déjà
 fi
 
 echo -e "\e[1m> Création d'une machine debian $DISTRIB minimaliste.\e[0m" | tee -a "$LOG_BUILD_LXC"
-sudo lxc-create -n $LXC_NAME -t debian -- -r $DISTRIB >> "$LOG_BUILD_LXC" 2>&1
+uname=$(uname -m)
+if [[ $uname =~ aarch64 ]]
+then
+        sudo lxc-create -n $LXC_NAME -t debian -- -r $DISTRIB  --arch=arm64 >> "$LOG_BUILD_LXC" 2>&1
+else
+        sudo lxc-create -n $LXC_NAME -t debian -- -r $DISTRIB >> "$LOG_BUILD_LXC" 2>&1
+fi
 
 echo -e "\e[1m> Autoriser l'ip forwarding, pour router vers la machine virtuelle.\e[0m" | tee -a "$LOG_BUILD_LXC"
 echo "net.ipv4.ip_forward=1" | sudo tee /etc/sysctl.d/lxc_pchecker.conf >> "$LOG_BUILD_LXC" 2>&1

--- a/sub_scripts/lxc_check.sh
+++ b/sub_scripts/lxc_check.sh
@@ -406,7 +406,12 @@ lxc_net_check=0 # Passe sur les différents tests
 while test "$lxc_net" -eq 1   # Boucle tant que la connexion internet du conteneur n'est pas réparée.
 do
 	REBOOT_CONTENEUR
-	sleep 30
+	if [ "$(uname -m)" == "aarch64" ]
+	then
+		sleep 30
+	else
+		sleep 3
+	fi
 	sudo lxc-ls -f
 	CHECK_LXC_NET
 	lxc_net=$?


### PR DESCRIPTION
lxc-create doesn't take in count aarch64 : https://uk.images.linuxcontainers.org/

But aarch64=arm64, so the changes do the trick to let install package_check on aarch64

In addition, when container start on aarch64, the container need more time to initialize network part, nslookup only respond after a few seconds. Adding some time after lxc start allow ping -q -c 2 security.debian.org or ping -q -c 2 yunohost.org to work