### PR TITLE
Testing

### DIFF
--- a/package_check.sh
+++ b/package_check.sh
@@ -50,6 +50,7 @@ interrupt=0
 notice=0
 build_lxc=0
 bash_mode=0
+show_resources=0
 
 # If no arguments provided
 if [ "$#" -eq 0 ]
@@ -70,6 +71,7 @@ else
 		arguments[$i]=${arguments[$i]//--help/-h}
 		arguments[$i]=${arguments[$i]//--build-lxc/-l}
 		arguments[$i]=${arguments[$i]//--bash-mode/-y}
+		arguments[$i]=${arguments[$i]//--show-resources/-r}
 	done
 
 	# Read and parse all the arguments
@@ -83,7 +85,7 @@ else
 				# Initialize the index of getopts
 				OPTIND=1
 				# Parse with getopts only if the argument begin by -
-				getopts ":b:fihly" parameter || true
+				getopts ":b:fihlyr" parameter || true
 				case $parameter in
 					b)
 						# --branch=branch-name
@@ -113,6 +115,11 @@ else
 					y)
 						# --bash-mode
 						bash_mode=1
+						shift_value=1
+						;;
+					r)
+						# --show-resources
+						show_resources=1
 						shift_value=1
 						;;
 					\?)
@@ -166,6 +173,8 @@ package_check.sh [OPTION]... PACKAGE_TO_CHECK
 		Install LXC and build the container if necessary.
 	-y, --bash-mode
 		Do not ask for continue check. Ignore auto_remove.
+	-r, --show-resources
+		Show the unavailable resources when accessing the url.
 EOF
 	exit 0
 fi

--- a/package_check.sh
+++ b/package_check.sh
@@ -1070,8 +1070,11 @@ then
 			if [ "${value:0:1}" = "1" ]
 			then
 				echo 1
-			else
+			elif [ "${value:0:1}" = "0" ]
+			then
 				echo 0
+            else
+                echo -1
 			fi
 		}
 

--- a/package_check.sh
+++ b/package_check.sh
@@ -1146,8 +1146,11 @@ then
 			then
 				# Add the commit to the upgrade list
 				line="${line##*from_commit=}"
-				echo "$line" >> "$script_dir/upgrade_list"
-			else
+                # Add the upgrade to the list only if the test is set to 1
+                if [ $temp_upgrade -eq 1 ]; then
+                    echo "$line" >> "$script_dir/upgrade_list"
+                fi
+			elif [ $temp_upgrade -eq 1 ]; then
 				# Or simply 'current' for a standard upgrade.
 				echo "current" >> "$script_dir/upgrade_list"
 			fi

--- a/package_check.sh
+++ b/package_check.sh
@@ -730,8 +730,13 @@ TEST_RESULTS () {
 			# Get maintained tag for this app.
 			maintained=$(echo "$json_app_part" | grep maintained | awk '{print $2}')
 			# If maintained isn't empty or at true. This app can't be tag as a High Quality app.
-			if [ "${maintained//,/}" != "true" ] && [ -n "$maintained" ]
+			# An app tagged as 'request_help' can still be High Quality, but not an app tagged as 'request_adoption'
+			if [ "${maintained//,/}" != "true" ] && [ "${maintained//[,\"]/}" != "request_help" ] && [ -n "$maintained" ]
 			then
+				if [ ${level[8]} -ge 1 ]
+				then
+					echo "As this app isn't maintained, it can't reach the level 8."
+				fi
 				level[8]=0
 			fi
 		fi

--- a/package_check.sh
+++ b/package_check.sh
@@ -562,19 +562,18 @@ TEST_RESULTS () {
 	# auto -> This level has not a value yet.
 	# na   -> This level will not be checked, but it'll be ignored in the final sum
 
-	# Set default values for level.
-	# All levels are forced to default values. Except the level 5.
-	level[1]=auto
-	level[2]=auto
-	level[3]=auto
-	level[4]=auto
-	# Level 5 can have a value forced into the check_process
+	# Set default values for level, if they're empty.
+	test -n "${level[1]}" || level[1]=auto
+	test -n "${level[2]}" || level[2]=auto
+	test -n "${level[3]}" || level[3]=auto
+	test -n "${level[4]}" || level[4]=auto
 	test -n "${level[5]}" || level[5]=auto
-	level[6]=auto
-	level[7]=auto
-	level[8]=0
-	level[9]=0
-	level[10]=0
+	test -n "${level[5]}" || level[5]=auto
+	test -n "${level[6]}" || level[6]=auto
+	test -n "${level[7]}" || level[7]=auto
+	test -n "${level[8]}" || level[8]=0
+	test -n "${level[9]}" || level[9]=0
+	test -n "${level[10]}" || level[10]=0
 
 	# Check if the level can be changed
 	level_can_change () {
@@ -944,13 +943,15 @@ then
 	extract_section "^;;; Levels" ";; " "$check_process"
 
 	# Get the value associated to each level
-	for i in `seq 1 10`
-	do
+	# Get only the value for the level 5 from the check_process
+# 	for i in `seq 1 10`
+# 	do
 		# Find the line for this level
-		line=$(find_string "^Level $i=")
+# 		line=$(find_string "^Level $i=")
+		line=$(find_string "^Level 5=")
 		# And get the value
 		level[$i]=$(echo "$line" | cut -d'=' -f2)
-	done
+# 	done
 
 
 	# Extract the Options section

--- a/sub_scripts/launcher.sh
+++ b/sub_scripts/launcher.sh
@@ -75,6 +75,14 @@ create_temp_backup () {
 	# Stop the container, before its snapshot
 	sudo lxc-stop --name $lxc_name >&2
 
+	# Remove swap files to avoid killing the CI with huge snapshots.
+	local swap_file="/var/lib/lxc/$lxc_name/rootfs/swap_$ynh_app_id"
+	if [ -e "$swap_file" ]
+	then
+        sudo swapoff "$swap_file"
+        sudo rm "$swap_file"
+	fi
+
 	# Check if the snapshot already exist
 	if [ ! -e "$snapshot_path/snap$snap_number" ]
 	then

--- a/sub_scripts/launcher.sh
+++ b/sub_scripts/launcher.sh
@@ -77,7 +77,7 @@ create_temp_backup () {
 
 	# Remove swap files to avoid killing the CI with huge snapshots.
 	local swap_file="/var/lib/lxc/$lxc_name/rootfs/swap_$ynh_app_id"
-	if [ -e "$swap_file" ]
+	if sudo test -e "$swap_file"
 	then
         sudo swapoff "$swap_file"
         sudo rm "$swap_file"

--- a/sub_scripts/log_extractor.sh
+++ b/sub_scripts/log_extractor.sh
@@ -74,6 +74,11 @@ FALSE_ERRORS_DETECTION () {
         false_positive_error=1
         false_positive_error_cond="DNS failure"
     fi
+    if grep --quiet "unable to resolve host address" "$temp_result"
+    then
+        false_positive_error=1
+        false_positive_error_cond="DNS failure"
+    fi
 
     # Detect Corrupt source
     if grep --quiet "Corrupt source" "$temp_result"

--- a/sub_scripts/log_extractor.sh
+++ b/sub_scripts/log_extractor.sh
@@ -57,6 +57,32 @@ COPY_LOG () {
 	fi
 }
 
+FALSE_ERRORS_DETECTION () {
+    # Detect false positive errors.
+    false_positive_error=0
+
+    # Detect network error
+    if grep --quiet "Network is unreachable" "$temp_result"
+    then
+        false_positive_error=1
+        false_positive_error_cond="network"
+    fi
+
+    # Detect DNS error
+    if grep --quiet "Temporary failure resolving" "$temp_result"
+    then
+        false_positive_error=1
+        false_positive_error_cond="DNS failure"
+    fi
+
+    # Detect Corrupt source
+    if grep --quiet "Corrupt source" "$temp_result"
+    then
+        false_positive_error=1
+        false_positive_error_cond="corrupt source"
+    fi
+}
+
 PARSE_LOG () {
 	# Print all errors and warning found in the log.
 
@@ -125,4 +151,5 @@ LOG_EXTRACTOR () {
 
 	CLEAR_LOG	# Remove all knew useless warning lines.
 	PARSE_LOG	# Print all errors and warning found in the log.
+	FALSE_ERRORS_DETECTION	# Detect if there's a temporary error that shouldn't impact the test.
 }

--- a/sub_scripts/testing_process.sh
+++ b/sub_scripts/testing_process.sh
@@ -380,8 +380,16 @@ CHECK_URL () {
 		done
 
 		# Detect the issue alias_traversal, https://github.com/yandex/gixy/blob/master/docs/en/plugins/aliastraversal.md
-		curl --location --insecure --silent $check_domain$check_path../html/index.nginx-debian.html \
-			| grep "title" | grep --quiet "Welcome to nginx on Debian" \
+
+		# Create a file to get for alias_traversal
+		echo "<!DOCTYPE html><html><head>
+<title>alias_traversal test</title>
+</head><body><h1>alias_traversal test</h1>
+If you see this page, you have failed the test for alias_traversal issue.</body></html>" \
+		| sudo tee /var/lib/lxc/$lxc_name/rootfs/var/www/html/alias_traversal.html > /dev/null
+
+		curl --location --insecure --silent $check_domain$check_path../html/alias_traversal.html \
+			| grep "title" | grep --quiet "alias_traversal test" \
 			&& ECHO_FORMAT "Issue alias_traversal detected ! Please see here https://github.com/YunoHost/example_ynh/pull/45 to fix that.\n" "red" "bold" && RESULT_alias_traversal=1
 
 		# Remove the entries in /etc/hosts for the test domain

--- a/sub_scripts/testing_process.sh
+++ b/sub_scripts/testing_process.sh
@@ -535,7 +535,7 @@ is_install_failed () {
     fi
 
     # If the test for install on root isn't desactivated
-    if [ $setup_root -ne 0 ]
+    if [ $setup_root -ne 0 ] || [ $setup_nourl -eq 1 ]
     then
         # If a test succeed or if force_install_ok is set
         if [ $RESULT_check_root -eq 1 ] || [ $force_install_ok -eq 1 ]

--- a/sub_scripts/testing_process.sh
+++ b/sub_scripts/testing_process.sh
@@ -356,64 +356,67 @@ CHECK_URL () {
 					lynx -dump -force_html "$script_dir/url_output" | head --lines 20 | tee --append "$test_result"
 					echo -e "\e[0m"
 
-					# Get all the resources for the main page of the app.
-					local HTTP_return
-					local moved=0
-					local ignored=0
-					while read HTTP_return
-					do
-						# Ignore robots.txt and ynhpanel.js. They always redirect to the portal.
-						if echo "$HTTP_return" | grep --quiet "$check_domain/robots.txt\|$check_domain/ynhpanel.js"; then
-							ECHO_FORMAT "Ressource ignored:" "white"
-							ECHO_FORMAT " ${HTTP_return##*http*://}\n"
-							ignored=1
-						fi
+					if [ $show_resources -eq 1 ]
+					then
+                        # Get all the resources for the main page of the app.
+                        local HTTP_return
+                        local moved=0
+                        local ignored=0
+                        while read HTTP_return
+                        do
+                            # Ignore robots.txt and ynhpanel.js. They always redirect to the portal.
+                            if echo "$HTTP_return" | grep --quiet "$check_domain/robots.txt\|$check_domain/ynhpanel.js"; then
+                                ECHO_FORMAT "Ressource ignored:" "white"
+                                ECHO_FORMAT " ${HTTP_return##*http*://}\n"
+                                ignored=1
+                            fi
 
-						# If it's the line with the resource to get
-						if echo "$HTTP_return" | grep --quiet "^--.*--  http"
-						then
-							# Get only the resource itself.
-							local resource=${HTTP_return##*http*://}
+                            # If it's the line with the resource to get
+                            if echo "$HTTP_return" | grep --quiet "^--.*--  http"
+                            then
+                                # Get only the resource itself.
+                                local resource=${HTTP_return##*http*://}
 
-						# Else, if would be the HTTP return code.
-						else
-							# If the return code is different than 200.
-							if ! echo "$HTTP_return" | grep --quiet "200 OK$"
-							then
-								# Skipped the check of ignored ressources.
-								if [ $ignored -eq 1 ]
-								then
-									ignored=0
-									continue
-								fi
-								# Isolate the http return code.
-								http_code="${HTTP_return##*awaiting response... }"
-								http_code="${http_code:0:3}"
-								# If the return code is 301 or 302, let's check the redirection.
-								if echo "$HTTP_return" | grep --quiet "30[12] Moved"
-								then
-									ECHO_FORMAT "Ressource moved:" "white"
-									ECHO_FORMAT " $resource\n"
-									moved=1
-								else
-									ECHO_FORMAT "Resource unreachable (Code $http_code)" "red" "bold"
-									ECHO_FORMAT " $resource\n"
-# 					 				curl_error=1
-									moved=0
-								fi
-							else
-								if [ $moved -eq 1 ]
-								then
-									if echo "$resource" | grep --quiet "/yunohost/sso/"
-									then
-										ECHO_FORMAT "The previous resource is redirected to the YunoHost portal\n" "red"
-#	 					 				curl_error=1
-									fi
-								fi
-								moved=0
-							fi
-						fi
-					done <<< "$(cd "$package_path"; LC_ALL=C wget --adjust-extension --page-requisites --no-check-certificate $check_domain$curl_check_path 2>&1 | grep "^--.*--  http\|^HTTP request sent")"
+                            # Else, if would be the HTTP return code.
+                            else
+                                # If the return code is different than 200.
+                                if ! echo "$HTTP_return" | grep --quiet "200 OK$"
+                                then
+                                    # Skipped the check of ignored ressources.
+                                    if [ $ignored -eq 1 ]
+                                    then
+                                        ignored=0
+                                        continue
+                                    fi
+                                    # Isolate the http return code.
+                                    http_code="${HTTP_return##*awaiting response... }"
+                                    http_code="${http_code:0:3}"
+                                    # If the return code is 301 or 302, let's check the redirection.
+                                    if echo "$HTTP_return" | grep --quiet "30[12] Moved"
+                                    then
+                                        ECHO_FORMAT "Ressource moved:" "white"
+                                        ECHO_FORMAT " $resource\n"
+                                        moved=1
+                                    else
+                                        ECHO_FORMAT "Resource unreachable (Code $http_code)" "red" "bold"
+                                        ECHO_FORMAT " $resource\n"
+#    					 				curl_error=1
+                                        moved=0
+                                    fi
+                                else
+                                    if [ $moved -eq 1 ]
+                                    then
+                                        if echo "$resource" | grep --quiet "/yunohost/sso/"
+                                        then
+                                            ECHO_FORMAT "The previous resource is redirected to the YunoHost portal\n" "red"
+#   	 					 				curl_error=1
+                                        fi
+                                    fi
+                                    moved=0
+                                fi
+                            fi
+                        done <<< "$(cd "$package_path"; LC_ALL=C wget --adjust-extension --page-requisites --no-check-certificate $check_domain$curl_check_path 2>&1 | grep "^--.*--  http\|^HTTP request sent")"
+                    fi
 					echo ""
 				fi
 			fi

--- a/sub_scripts/testing_process.sh
+++ b/sub_scripts/testing_process.sh
@@ -525,7 +525,8 @@ is_install_failed () {
     if [ $setup_sub_dir -ne 0 ]
     then
         # If a test succeed or if force_install_ok is set
-        if [ $RESULT_check_sub_dir -eq 1 ] || [ $force_install_ok -eq 1 ]
+        # Or if $setup_sub_dir isn't set in the check_process
+        if [ $RESULT_check_sub_dir -eq 1 ] || [ $force_install_ok -eq 1 ] || [ $setup_sub_dir -eq -1 ]
         then
             # Validate installation in sub dir.
             sub_dir_install=1
@@ -535,10 +536,12 @@ is_install_failed () {
     fi
 
     # If the test for install on root isn't desactivated
+
     if [ $setup_root -ne 0 ] || [ $setup_nourl -eq 1 ]
     then
         # If a test succeed or if force_install_ok is set
-        if [ $RESULT_check_root -eq 1 ] || [ $force_install_ok -eq 1 ]
+        # Or if $setup_root isn't set in the check_process
+        if [ $RESULT_check_root -eq 1 ] || [ $force_install_ok -eq 1 ] || [ $setup_root -eq -1 ]
         then
             # Validate installation on root.
             root_install=1


### PR DESCRIPTION
- Restart tests when a temporary error happens, to avoid complete failure for stupid errors.
- Do not fails to perform test if no install have been done before. (Allow all tests to run without a previous install test)
- Create snapshot for successful install even out of the first installations.
- Add an option `--show-resources` to show unavailable resources when accessing the url.
- Fix an error with multiple upgrade_from with some set to 0
- [Work in progress] Remove swap file before creating snapshots to prevent a crash of the CI by lack of free space.