### PR TITLE
Use rsync to push package and delete old files

### DIFF
--- a/sub_scripts/launcher.sh
+++ b/sub_scripts/launcher.sh
@@ -286,7 +286,7 @@ $(cat "$script_dir/sub_scripts/Build_lxc.log")"
 	COPY_LOG 1
 
 	# Copy the package into the container.
-	scp -rq "$package_path" "$lxc_name": >> "$test_result" 2>&1
+	rsync -rq --delete "$package_path" "$lxc_name": >> "$test_result" 2>&1
 
 	# Execute the command given in argument in the container and log its results.
 	ssh $arg_ssh $lxc_name "$1 > /dev/null 2>> temp_yunohost-cli.log; exit \$?" >> "$test_result" 2>&1


### PR DESCRIPTION
# Problem

When we remove patch in a new package version it's not removed in the test. In case of test of an upgrade could have some old patch which is applied but it should because it was removed.

# Solution

Use rsync wich give the possiblity to remove old file.

# Status

Tested locally. And it work.