### PR TITLE
Handle return code from linter saying the app should be flagged as broken

### DIFF
--- a/package_check.sh
+++ b/package_check.sh
@@ -804,6 +804,13 @@ TEST_RESULTS () {
 		global_level=0
 	fi
 
+	# If the package linter returned a critical error, the app is flagged as broken / level 0
+	if [ $RESULT_linter -eq -2 ]
+	then
+		ECHO_FORMAT "The package linter reported a critical failure ! App is considered broken !\n" "red" "bold"
+		global_level=0
+	fi
+
 	if [ $RESULT_alias_traversal -eq 1 ]
 	then
 		ECHO_FORMAT "Issue alias_traversal was detected ! Please see here https://github.com/YunoHost/example_ynh/pull/45 to fix that.\n" "red" "bold"

--- a/sub_scripts/testing_process.sh
+++ b/sub_scripts/testing_process.sh
@@ -1500,6 +1500,12 @@ PACKAGE_LINTER () {
 	else	# Fail
 		check_failed
 		RESULT_linter=-1
+
+        # If return code is 2, this is critical failure, app should be considered as broken (level 0)
+        if [ $linter_result -eq 2 ]
+        then
+            RESULT_linter=-2
+        fi
 	fi
 }
 


### PR DESCRIPTION
**Not tested** :/ 

That's a follow-up of https://github.com/YunoHost/package_linter/pull/77 to handle a new special return code (2) meaning the app should be considered as broken / level 0