### PR TITLE
Test incorrect_path is obsolete and should be removed

### DIFF
--- a/package_check.sh
+++ b/package_check.sh
@@ -1200,7 +1200,7 @@ then
 		count_test $backup_restore
 		multi_instance=$(read_check_option multi_instance)
 		count_test $multi_instance
-		incorrect_path=$(read_check_option incorrect_path)
+		incorrect_path=0
 		count_test $incorrect_path
 		port_already_use=$(read_check_option port_already_use)
 		count_test $port_already_use
@@ -1286,7 +1286,7 @@ else
 	setup_public=1
 	backup_restore=1
 	multi_instance=1
-	incorrect_path=1
+	incorrect_path=0
 	port_already_use=0
 	change_url=0
 	all_test=$((all_test+9))


### PR DESCRIPTION
In an attempt to reduce the time it takes to run package_check, it should be noticed that incorrect_path is now obsolete since 2.7 yet is still ran for many apps. The only reason it could still be relevant is for a handful of apps that use `path=$2` for example (instead of `$YNH_APP_...`). This is now also fixed in 3.8 so this test is obsolete.

Note that the test port_already_used also seems overkilled for apps that do not ask a port argument from the manifest. (Typically it's only about making sure that apps obtain a port using `ynh_find_port` which can easily be checked from the package linter)