### PR TITLE
Disable check_template

### DIFF
--- a/sub_scripts/testing_process.sh
+++ b/sub_scripts/testing_process.sh
@@ -2204,7 +2204,7 @@ TESTING_PROCESS () {
 		PACKAGE_LINTER
 	fi
 
-	CHECK_TEMPLATE
+	#CHECK_TEMPLATE
 
 	# Try to install in a sub path
 	if [ $setup_sub_dir -eq 1 ]; then


### PR DESCRIPTION
People are repeatedly confused by these checks which ain't accurate/relevant in many situation (e.g. script is legitimately small and therefore there isn't much comment etc...) yet because the messages are in screaming red people think there's a huge error going on ...

So proposing to disable this until these checks are made more accurate...