### PR TITLE
run pre_install for restore on fresh container

### DIFF
--- a/sub_scripts/testing_process.sh
+++ b/sub_scripts/testing_process.sh
@@ -1462,6 +1462,28 @@ CHECK_BACKUP_RESTORE () {
 				# Uses the default snapshot
 				current_snapshot=snap0
 
+				# Exec the pre-install instruction, if there one
+				if [ -n "$pre_install" ]
+				then
+					ECHO_FORMAT "Pre installation request\n" "white" "bold" clog
+					# Start the lxc container
+					LXC_START "true"
+					# Copy all the instructions into a script
+					echo "$pre_install" > "$script_dir/preinstall.sh"
+					chmod +x "$script_dir/preinstall.sh"
+					# Replace variables
+					sed -i "s/\$USER/$test_user/" "$script_dir/preinstall.sh"
+					sed -i "s/\$DOMAIN/$main_domain/" "$script_dir/preinstall.sh"
+					sed -i "s/\$SUBDOMAIN/$sub_domain/" "$script_dir/preinstall.sh"
+					sed -i "s/\$PASSWORD/$yuno_pwd/" "$script_dir/preinstall.sh"
+					# Copy the pre-install script into the container.
+					scp -rq "$script_dir/preinstall.sh" "$lxc_name":
+					# Then execute the script to execute the pre-install commands.
+					LXC_START "./preinstall.sh >&2"
+					# Print the log to print the results
+					ECHO_FORMAT "$(cat "$temp_log")\n" clog
+				fi
+
 				# Remove the previous residual backups
 				sudo rm -rf /var/lib/lxcsnaps/$lxc_name/$current_snapshot/rootfs/home/yunohost.backup/archives
 


### PR DESCRIPTION
Problem: 
Restore on backup is tested twice:
- after removing the app
- after restoring the container => the pre-installed app is not present anymore
Restore is failing for apps which require pre-install of another app. For instance matrix bridges require install of synapse, see: https://github.com/YunoHost-Apps/mautrix_whatsapp_ynh/blob/master/check_process

Solution:
run the pre install commands after restoring the container.