### PR TITLE
Integrate level list directly into package_check

### DIFF
--- a/levels.list
+++ b/levels.list
@@ -1,0 +1,11 @@
+0  Broken
+1  Installable
+2  Installable in all situations
+3  Can be updated
+4  Backup and restore support
+5  Clean
+6  Open to contributions from the community
+7  Successfully pass functional tests
+8  High quality app
+9  Respect higher guidelines
+10 Package assessed as perfect

--- a/package_check.sh
+++ b/package_check.sh
@@ -264,9 +264,6 @@ rm "$script_dir/pcheck.lock"
 exec "$script_dir/package_check.sh" "${arguments[@]}"
 EOF
 
-		# Get the last version of app_levels/en.json
-		wget -nv https://raw.githubusercontent.com/YunoHost/apps/master/app_levels/en.json -O "$script_dir/levels.json"
-
 		# Give the execution right
 		chmod +x "$script_dir/upgrade_script.sh"
 
@@ -856,7 +853,7 @@ TEST_RESULTS () {
 
 	# Then, print the levels
 	# Print the global level
-	verbose_level=$(grep applevel_$global_level\" "$script_dir/levels.json" | cut -d'"' -f4)
+	verbose_level=$(grep "^$global_level " "$script_dir/levels.list" | cut -c4-)
 
 	ECHO_FORMAT "Level of this application: $global_level ($verbose_level)\n" "white" "bold"
 


### PR DESCRIPTION
Not the most revolutionary change ever, but while starting to work on something else in package_check, I remember about this level list that's sitting in https://github.com/YunoHost/apps/tree/master/app_levels and this list (and translation) is actually not used anywhere else besides package_check ... so this is an attempt to simplify / clean things by moving them in package check directly