### PR TITLE
Check that master branch does indeed exists or fallback to stable

### DIFF
--- a/package_check.sh
+++ b/package_check.sh
@@ -517,7 +517,18 @@ then
     # Force the branch master if no branch is specified.
     if [ -z "$gitbranch" ]
     then
-        gitbranch="-b master"
+        if git ls-remote --quiet --exit-code $app_arg master
+        then
+            gitbranch="-b master"
+        else
+            if git ls-remote --quiet --exit-code $app_arg stable
+            then
+                gitbranch="-b stable"
+            else
+                ECHO_FORMAT "Unable to find a default branch to test (master or stable)" "red"
+                clean_exit 1
+            fi
+        fi
     fi
 	# Clone the repository
 	git clone $app_arg $gitbranch "$package_path"


### PR DESCRIPTION
c.f. neutrinet_ynh whose main branch is stable and not master 

https://github.com/YunoHost/apps/blob/master/apps.json#L1994

therefore the CI fails miserably : 

https://ci-apps.yunohost.org/ci/job/2333