### PR TITLE
Fix the creation of containers on arm boards

### DIFF
--- a/sub_scripts/lxc_build.sh
+++ b/sub_scripts/lxc_build.sh
@@ -96,13 +96,7 @@ then	# Si le conteneur existe déjà
 fi
 
 echo -e "\e[1m> Création d'une machine debian $DISTRIB minimaliste.\e[0m" | tee -a "$LOG_BUILD_LXC"
-if [ "$(uname -m)" == "aarch64" ]
-then
-        arch_arg="--arch=arm64"
-else
-        arch_arg=""
-fi
-sudo lxc-create -n $LXC_NAME -t debian -- -r $DISTRIB $arch_arg >> "$LOG_BUILD_LXC" 2>&1
+sudo lxc-create -n $LXC_NAME -t download -- -d debian -r $DISTRIB -a $(dpkg --print-architecture) >> "$LOG_BUILD_LXC" 2>&1
 
 echo -e "\e[1m> Autoriser l'ip forwarding, pour router vers la machine virtuelle.\e[0m" | tee -a "$LOG_BUILD_LXC"
 echo "net.ipv4.ip_forward=1" | sudo tee /etc/sysctl.d/lxc_pchecker.conf >> "$LOG_BUILD_LXC" 2>&1


### PR DESCRIPTION
On my rpi2 (and on the rpi3 of ppr) the script fails miserably when trying to create a debian buster container with this error:

> Création d'une machine debian buster minimaliste.
debootstrap is /usr/sbin/debootstrap
Checking cache download in /var/cache/lxc/debian/rootfs-buster-armhf ... 
gpg: key 7638D0442B90D010: 4 signatures not checked due to missing keys
gpg: key 7638D0442B90D010: "Debian Archive Automatic Signing Key (8/jessie) <ftpmaster@debian.org>" not changed
gpg: Total number processed: 1
gpg:              unchanged: 1
Downloading debian minimal ...
I: Target architecture can be executed
I: Retrieving InRelease 
I: Checking Release signature
**E: Release signed by unknown key (key id DCC9EFBF77E11517)**
    **The specified keyring /var/cache/lxc/debian/archive-key.gpg may be incorrect or out of date.**
    **You can find the latest Debian release key at https://ftp-master.debian.org/keys.html**
Failed to download the rootfs, aborting.
Failed to download 'debian base'
failed to install debian
lxc-create: pchecker_lxc: lxccontainer.c: create_run_template: 1617 Failed to create container from template
lxc-create: pchecker_lxc: tools/lxc_create.c: main: 327 Failed to create container pchecker_lxc

To solve the problem, we download the latest template and create a debian buster container from it.