### PR TITLE
disable trap SIGINT in cleanup

### DIFF
--- a/package_check.sh
+++ b/package_check.sh
@@ -123,6 +123,7 @@ parse_args
 
 function cleanup()
 {
+    trap '' SIGINT # Disable ctrl+c in this function
     LXC_RESET
 
     [ -n "$TEST_CONTEXT" ] && rm -rf "$TEST_CONTEXT"


### PR DESCRIPTION
When I try to stop the tests, I mash `ctrl + c` until package_check ends (otherwise it will start the following test). But the cleanup function stop running because of that.
I think we can disable ctrl+c signal (SIGINT) during the cleanup function