### PR TITLE
Add lynx in the apt install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ be able to install `snapd` using the system package manager (or even
 `lxd` directly).
 
 ```bash
-apt install git snapd
+apt install git snapd lynx
 sudo snap install core
 sudo snap install lxd
 


### PR DESCRIPTION
Upon first `./package_check.sh app_ynh` command, the script complains about `lynx` not being installed. Let's make sure it is installed like the other dependencies.