### PR TITLE
Fix lxc exec

### DIFF
--- a/lib/lxc.sh
+++ b/lib/lxc.sh
@@ -91,7 +91,7 @@ LXC_EXEC () {
     start_timer
 
     # Execute the command given in argument in the container and log its results.
-    lxc exec $LXC_NAME --env PACKAGE_CHECK_EXEC=1 -t -- $cmd | tee -a "$complete_log" $current_test_log
+    lxc exec $LXC_NAME --env PACKAGE_CHECK_EXEC=1 -t -- /bin/bash -c "$cmd" | tee -a "$complete_log" $current_test_log
 
     # Store the return code of the command
     local returncode=${PIPESTATUS[0]}

--- a/lib/tests.sh
+++ b/lib/tests.sh
@@ -80,8 +80,8 @@ _INSTALL_APP () {
     done
 
     # Install the application in a LXC container
-    log_info "Running: yunohost app install --force /app_folder -a $install_args"
-    _RUN_YUNOHOST_CMD "app install --force /app_folder -a $install_args"
+    log_info "Running: yunohost app install --force /app_folder -a \"$install_args\""
+    _RUN_YUNOHOST_CMD "app install --force /app_folder -a \"$install_args\""
 
     local ret=$?
     [ $ret -eq 0 ] && log_debug "Installation successful." || log_error "Installation failed."

--- a/lib/tests.sh
+++ b/lib/tests.sh
@@ -886,12 +886,12 @@ ACTIONS_CONFIG_PANEL () {
                         then
                             # Build the argument from a value from the check_process
                             local action_config_actual_argument="$(echo "$actions_config_arguments_specifics" | cut -d'|' -f $j)"
-                            action_config_argument_built="--args $action_config_argument_name=$action_config_actual_argument"
+                            action_config_argument_built="--args \"$action_config_argument_name=$action_config_actual_argument\""
                         elif [ -n "$action_config_argument_default" ]
                         then
                             # Build the argument from the default value
                             local action_config_actual_argument="$action_config_argument_default"
-                            action_config_argument_built="--args $action_config_argument_name=$action_config_actual_argument"
+                            action_config_argument_built="--args \"$action_config_argument_name=$action_config_actual_argument\""
                         else
                             log_warning "> No argument into the check_process to use or default argument for \"$action_config_name\"..."
                             action_config_actual_argument=""

--- a/lib/tests_coordination.sh
+++ b/lib/tests_coordination.sh
@@ -78,7 +78,7 @@ parse_check_process() {
         # Looking like domain=foo.com&path=/bar&password=stuff
         # "Standard" arguments like domain/path will later be overwritten
         # during tests
-        local install_args=$(       extract_check_process_section "^; Manifest"     "^; " $test_serie_rawconf | tr '\n' '&')
+        local install_args=$(       extract_check_process_section "^; Manifest"     "^; " $test_serie_rawconf | awk '{print $1}' | tr -d '"' | tr '\n' '&')
         local preinstall_template=$(extract_check_process_section "^; pre-install"  "^; " $test_serie_rawconf)
         local action_infos=$(       extract_check_process_section "^; Actions"      "^; " $test_serie_rawconf)
         local configpanel_infos=$(  extract_check_process_section "^; Config_panel" "^; " $test_serie_rawconf)

--- a/lib/tests_coordination.sh
+++ b/lib/tests_coordination.sh
@@ -78,7 +78,7 @@ parse_check_process() {
         # Looking like domain=foo.com&path=/bar&password=stuff
         # "Standard" arguments like domain/path will later be overwritten
         # during tests
-        local install_args=$(       extract_check_process_section "^; Manifest"     "^; " $test_serie_rawconf | awk '{print $1}' | tr -d '"' | tr '\n' '&')
+        local install_args=$(       extract_check_process_section "^; Manifest"     "^; " $test_serie_rawconf | tr '\n' '&')
         local preinstall_template=$(extract_check_process_section "^; pre-install"  "^; " $test_serie_rawconf)
         local action_infos=$(       extract_check_process_section "^; Actions"      "^; " $test_serie_rawconf)
         local configpanel_infos=$(  extract_check_process_section "^; Config_panel" "^; " $test_serie_rawconf)

--- a/lib/tests_coordination.sh
+++ b/lib/tests_coordination.sh
@@ -108,10 +108,14 @@ parse_check_process() {
             # Upgrades with a specific commit
             if [[ "$test_type" == "TEST_UPGRADE" ]] && [[ -n "$test_arg" ]]
             then
-                local specific_upgrade_install_args="$(grep "^manifest_arg=" "$TEST_CONTEXT/upgrades/$test_arg" | cut -d'=' -f2-)"
-                [[ -n "$specific_upgrade_install_args" ]] && _install_args="$specific_upgrade_install_args"
+                if [ -f "$TEST_CONTEXT/upgrades/$test_arg" ]; then
+                    local specific_upgrade_install_args="$(grep "^manifest_arg=" "$TEST_CONTEXT/upgrades/$test_arg" | cut -d'=' -f2-)"
+                    [[ -n "$specific_upgrade_install_args" ]] && _install_args="$specific_upgrade_install_args"
 
-                local upgrade_name="$(grep "^name=" "$TEST_CONTEXT/upgrades/$test_arg" | cut -d'=' -f2)"
+                    local upgrade_name="$(grep "^name=" "$TEST_CONTEXT/upgrades/$test_arg" | cut -d'=' -f2)"
+                else
+                    local upgrade_name="$test_arg"
+                fi
                 extra="$(jq -n --arg upgrade_name "$upgrade_name" '{ $upgrade_name }')"
             elif [[ "$test_type" == "ACTIONS_CONFIG_PANEL" ]] && [[ "$test_arg" == "actions" ]]
             then


### PR DESCRIPTION
Fix: 
> su: invalid option -- 'r'
> Try 'su --help' for more information.

And when an arg is a sentence and not just a word
(for example: https://ci-apps.yunohost.org/ci/job/213, https://github.com/YunoHost-Apps/unattended_upgrades_ynh/blob/4e342d41ea448c4a9de2bbbc6b6cffe92320ef71/check_process#L3)