### PR TITLE
preinstall during upgrade

### DIFF
--- a/lib/tests.sh
+++ b/lib/tests.sh
@@ -410,6 +410,8 @@ TEST_UPGRADE () {
 
         LOAD_LXC_SNAPSHOT snap0
 
+        _PREINSTALL
+
         # Install the application
         _INSTALL_APP "path=$check_path"
 


### PR DESCRIPTION
There are packages like https://github.com/YunoHost-Apps/yunorunner_ynh_core that require pre-installed stuff. but when running a test upgrade from previous version, previous version install fails because pre-installed stuff is not installed ....

Just trying to fix that ... Ugly...