### PR TITLE
Retrieve only one IP address

### DIFF
--- a/lib/lxc.sh
+++ b/lib/lxc.sh
@@ -204,7 +204,7 @@ _LXC_START_AND_WAIT() {
 		fi
 	done
 
-    LXC_IP=$(lxc exec $1 -- hostname -I | grep -E -o "\<[0-9.]{8,}\>")
+    LXC_IP=$(lxc exec $1 -- hostname -I | cut -d' ' -f1 | grep -E -o "\<[0-9.]{8,}\>")
 }
 
 CLEAN_SWAPFILES() {


### PR DESCRIPTION
I was struggling on some package_check without understanding the result of the `[Test 2/6] Installation on the root` test:
https://ci-apps-dev.yunohost.org/ci/job/3189

```
Error: Connection error...
Warning: Test URL: sub.domain.tld
Real URL: curl: no URL specified!

curl: try 'curl --help' or 'curl --manual' for more information

/bin/bash: line 2: 192.168.47.254: command not found

/bin/bash: line 3: 192.168.47.254: command not found

/bin/bash: line 4: 192.168.47.254: command not found

/bin/bash: line 5: 192.168.47.254: command not found

HTTP code: curl: no URL specified!

curl: try 'curl --help' or 'curl --manual' for more information

/bin/bash: line 2: 192.168.47.254: command not found

/bin/bash: line 3: 192.168.47.254: command not found

/bin/bash: line 4: 192.168.47.254: command not found

/bin/bash: line 5: 192.168.47.254: command not found

Page title: 
Page extract:
   cat: ./curl_output: No such file or directory
```

After some digging, I don't know why, sometimes the LXC has 2 ip addresses ...
![image](https://user-images.githubusercontent.com/30271971/190518184-533a5a58-64b0-4abd-8ecd-a688df04da75.png)


So I manage to only retrieve one of them, so when doing : https://github.com/YunoHost/package_check/blob/f9dafe3a41412a7136e4700f4b046ea977aef4d3/lib/tests.sh#L215-L224

LXC_IP value will be: `192.168.47.115` instead of 
```
192.168.47.115
192.168.47.114
```

