### PR TITLE
Don't let systemctl open a pager to list units...

### DIFF
--- a/lib/tests.sh
+++ b/lib/tests.sh
@@ -284,8 +284,8 @@ Page extract:\n$page_extract" > $TEST_CONTEXT/curl_result
         # If we had a 50x error, try to display service info and logs to help debugging
         if [[ $curl_error -ne 0 ]] && echo "5" | grep -q "${http_code:0:1}"
         then
-            LXC_EXEC "systemctl --all" | grep "$app_id_to_check.*service"
-            for SERVICE in $(LXC_EXEC "systemctl -all" | grep -o "$app_id_to_check.*service")
+            LXC_EXEC "systemctl --no-pager --all" | grep "$app_id_to_check.*service"
+            for SERVICE in $(LXC_EXEC "systemctl --no-pager -all" | grep -o "$app_id_to_check.*service")
             do
                 LXC_EXEC "journalctl --no-pager --no-hostname -n 30 -u $SERVICE";
             done


### PR DESCRIPTION
... or it will hang in in interactive terminal

This only happens when the check URL step failed: package_check tries to list all systemd services to find a service matching the app. When running on CI, this works fine, but running manually in a "real" terminal just stalls forever because systemctl opened a pager to view the list of services interactively.