### PR TITLE
Add metrics measurements to tests runs

### DIFF
--- a/lib/tests_coordination.sh
+++ b/lib/tests_coordination.sh
@@ -104,6 +104,9 @@ TEST_LAUNCHER () {
     # And keep this value separately
     local global_start_timer=$starttime
 
+    # Start metrics measurement
+    metrics_start
+
     current_test_id=$(basename $testfile | cut -d. -f1)
     current_test_infos="$TEST_CONTEXT/tests/$current_test_id.json"
     current_test_results="$TEST_CONTEXT/results/$current_test_id.json"
@@ -152,6 +155,9 @@ TEST_LAUNCHER () {
     starttime=$global_start_timer
     # End the timer for the test
     stop_timer one_test
+
+    # Stop metrics and show results
+    metrics_stop
 
     LXC_STOP $LXC_NAME
 


### PR DESCRIPTION
This addition provides metrics measurements for package_check. The idea is to provide app maintainers infos about their apps that they will be able to fill into the manifestv2.

Todo:
- [x] Print metrics at the end of each test
- [x] Test
- [ ] Print metrics in the final summary
- [ ] Check if the max resources indicated in the manifestv2 are compatible with the measurements