### PR TITLE
Fix get_default_values

### DIFF
--- a/lib/default_install_args.py
+++ b/lib/default_install_args.py
@@ -35,8 +35,8 @@ def get_default_values_for_questions(manifest, raise_if_no_default=True):
         elif question["type"] == "password":
             yield (name, "SomeSuperStrongPassword1234")
         elif question.get("choices"):
-            if isinstance(question["choices"]):
-                choices = str(question["choices"])
+            if isinstance(question["choices"], list):
+                choices = question["choices"]
             else:
                 choices = list(question["choices"].keys())
             yield (name, choices[0])


### PR DESCRIPTION
For choices, default value is the first of either list or dict.

The current code is buggy because isinstance() requires a variable and a type.