### PR TITLE
Allow overriding is_webapp parameter in tests.toml

### DIFF
--- a/lib/parse_tests_toml.py
+++ b/lib/parse_tests_toml.py
@@ -13,6 +13,10 @@ def generate_test_list_base(test_manifest, default_install_args, is_webapp, is_m
 
     is_full_domain_app = "domain" in default_install_args and "path" not in default_install_args
 
+    if test_manifest.get("webapp") is not None:
+        assert isinstance(test_manifest["webapp"], bool), "webapp must be a boolean value"
+        is_webapp = test_manifest["webapp"]
+
     for test_suite_id, test_suite in test_manifest.items():
 
         # Ignore non-testsuite stuff like "test_format"


### PR DESCRIPTION
`package_check` tries to [grep](https://github.com/YunoHost/package_check/blob/7cdffc745ce183e2dded9507aa1b691120150481/lib/parse_tests_toml.py#L142) for `^ynh_add_nginx_config` in order to decide whether tests with URL should be launched at all. I put `ynh_add_nginx_config` invocation in `scripts/_common.sh` in order to reuse some code between `install` and `upgrade` as a functions. With this approach `package_check` attempts to install my application only with `nourl` scenario. That's not correct. The following change makes it possible to override `is_webapp` parameter during tests by setting `webapp` in `tests.toml`.

Note that invoking `ynh_add_nginx_config` conditionally like:

```
if [ "$something" = 1 ]; then
    ynh_add_nginx_config
fi
```

would also make `package_check` treat application as a non-webapp, even though that's not true.