### PR TITLE
Force current hour in UTC and show explicitly that we’re using UTC

### DIFF
--- a/lib/common.sh
+++ b/lib/common.sh
@@ -170,7 +170,7 @@ stop_timer () {
     [ $minutes -eq 1 ] && pminutes="${pminutes}, " || test -z "$pminutes" || pminutes="${pminutes}s, "
     [ $seconds -gt 1 ] && pseconds="${pseconds}s" || pseconds="0s"
 
-    local time="${phours}${pminutes}${pseconds} ($(date '+%T'))"
+    local time="${phours}${pminutes}${pseconds} ($(date '+%T %Z' -u))"
     if [ "$msg_type" = "one_test" ]; then
         log_info "Working time for this test: $time"
     elif [ "$msg_type" = "all_tests" ]; then


### PR DESCRIPTION
The current time display is ambiguous:
> Working time for this test: 4 minutes, 16 seconds (02:19:02)

So i changed the `date` command to force the UTC usage (in fact the showed time will remain unchanged, as the server already uses UTC) and to show that we’re using UTC timezone, removing any ambiguity:
> Working time for this test: 4 minutes, 16 seconds (02:19:02 UTC)