### PR TITLE
When testing for app page access, reuse cookies between requests.

### DIFF
--- a/lib/tests.sh
+++ b/lib/tests.sh
@@ -268,7 +268,7 @@ _VALIDATE_THAT_APP_CAN_BE_ACCESSED () {
             log_debug "Running curl $check_domain$curl_check_path"
 
             # Call cURL to try to access to the URL of the app
-            LXC_EXEC "curl --location --insecure --silent --show-error \
+            LXC_EXEC "curl --location --insecure --silent --show-error --cookie /dev/null \
                 --header 'Host: $check_domain' \
                 --resolve $DOMAIN:80:$LXC_IP \
                 --resolve $DOMAIN:443:$LXC_IP \


### PR DESCRIPTION
cURL --location will follow redirects, but by default won't reuse cookies. 

Some apps, like Jackett, might add authentication cookies in a chain of redirections.

Passing --cookie <useless file> to cURL tells it to keep cookies between 'sessions'.