### PR TITLE
Add more entries to the .gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,8 @@ config
 curl_print
 
 *.lock
+
+.apps/
+.*.schema.json
+lib/__pycache__/
+package_linter/


### PR DESCRIPTION
I'm not sure if package_linter should be in the gitignore but since it's not in the repo as a submodule i assume yes?