### PR TITLE
Add a -v/--verbose flag to print debug output

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,14 +30,17 @@ The app is expected to contain a `tests.toml` file (see below) to tell package_c
 
 ## Usage
 
+<!--STARTHELP-->
+
 ```text
 > ./package_check.sh --help
  Usage: package_check.sh [OPTION]... PACKAGE_TO_CHECK
 
-    -b, --branch=BRANCH     Specify a branch to check.
+    -b, --branch=BRANCH         Specify a branch to check.
     -a, --arch=ARCH
     -d, --dist=DIST
     -y, --ynh-branch=BRANCH
+    -D, --dry-run               Show a JSON representing which tests are going to be ran (meant for debugging)
     -i, --interactive           Wait for the user to continue before each remove
     -e, --interactive-on-errors Wait for the user to continue on errors
     -s, --force-stop            Force the stop of running package_check
@@ -45,74 +48,14 @@ The app is expected to contain a `tests.toml` file (see below) to tell package_c
                                 (N.B.: you're not supposed to use this option,
                                 images are supposed to be fetch from
                                 devbaseimgs.yunohost.org automatically)
+    -S, --storage-dir DIRECTORY Where to store temporary test files like yunohost backups
+    -v, --verbose               Prints the complete debug log to screen
     -h, --help                  Display this help
+
+    Pass YNHDEV_BACKEND=incus|lxd to use a specific LXD-compatible backend.
 ```
 
-## Deploying package_check
-
-First you need to install the system dependencies.
-
-Package check is based on the LXD/LXC ecosystem. Be careful that
-**LXD can conflict with other installed virtualization technologies such as
-libvirt or vanilla LXCs**, especially because they all require a daemon based
-on DNSmasq which may list on port 53.
-
-On a Debian-based system (regular Debian, Ubuntu, Mint ...), LXD can be
-installed using `snapd`. On other systems like Archlinux, you will probably also
-be able to install `snapd` using the system package manager (or even
-`lxd` directly).
-
-```bash
-apt install git snapd lynx jq
-sudo snap install core
-sudo snap install lxd
-
-# Adding lxc/lxd to /usr/local/bin to make sure we can use them easily even
-# with sudo for which the PATH is defined in /etc/sudoers and probably doesn't
-# include /snap/bin
-sudo ln -s /snap/bin/lxc /usr/local/bin/lxc
-sudo ln -s /snap/bin/lxd /usr/local/bin/lxd
-```
-
-NB. : you should **make sure that your user is in the `lxd` group** so that it's
-able to run `lxc` commands without sudo... You can check this with the command
-`groups` where you should see `lxd`. Otherwise, add your user to this group
-(don't forget that you may need to reload your entire graphical session for this
-to propagate (sigh))
-
-Then you shall initialize LXD which will ask you a bunch of question. Usually
-answering the default (just pressing enter) to all questions is fine. Just pay
-attention to :
-
-- the storage backend driver. Possibly `zfs` is the best, but requires a kernel >= 5.x
-  and corresponding kernel module loaded. You can fallback to the `dir` driver.
-- the size of the default storage it'll create (the default is 5G but you may
-  want 10G for heavy usage ?) (if you're using the 'dir' driver, this won't be asked)
-
-```bash
-lxd init
-```
-
-The base images for tests are centralized on `devbaseimgs.yunohost.org` and we'll download them from there to speed things up:
-
-```bash
-lxc remote add yunohost https://devbaseimgs.yunohost.org --public
-```
-
-(At the time this README is written, fingerprint is d9ae6e76c374e3c58c3c20a881cffe7435809adb3b222ec393805f5bd01bb522 )
-
-Then you can install package check :
-
-```
-git clone https://github.com/YunoHost/package_check
-cd package_check
-```
-
-Then test your packages :
-
-```
-./package_check.sh your_app_ynh
-```
+<!--ENDHELP-->
 
 ## You can start a container on a different architecture with some hacks
 

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -129,7 +129,13 @@ function log_small_title()
 
 function log_debug()
 {
-    echo "$1" >> /proc/self/fd/3
+    if [[ "$verbose_log" = "1" ]]; then
+        # Append to log file and print to screen
+        echo "${1}" | tee -a /proc/self/fd/3
+    else
+        # Only append to log file, don't print to screen
+        echo "$1" >> /proc/self/fd/3
+    fi
 }
 
 function log_info()

--- a/lib/update_readme.py
+++ b/lib/update_readme.py
@@ -1,0 +1,32 @@
+#! /usr/bin/env python3
+
+import os 
+from pathlib import Path
+
+BASEDIR = os.path.realpath(os.path.dirname(os.path.realpath(__file__)) + "/..")
+README = Path(BASEDIR) / "README.md"
+SCRIPT = Path(BASEDIR) / "package_check.sh"
+
+with open(SCRIPT) as f:
+    content = f.read()
+    help = content.split("#STARTHELP")[1].split("#ENDHELP")[0]
+    # Remove first 2 lines
+    help = "\n".join(help.split("\n")[2:])
+    # Remove last 3 lines
+    help = "\n".join(help.split("\n")[:-3])
+
+with open(README) as f:
+    content = f.read()
+    start = content.split("<!--STARTHELP-->")[0]
+    end = content.split("<!--ENDHELP-->")[1]
+
+readme_content = start \
+    + "<!--STARTHELP-->\n\n" \
+    + "```text\n" \
+    + "> ./package_check.sh --help\n" \
+    + help \
+    + "\n```\n\n<!--ENDHELP-->" \
+    + end
+
+with open(README, "w") as f:
+    f.write(readme_content)

--- a/package_check.sh
+++ b/package_check.sh
@@ -9,7 +9,7 @@ print_help() {
     cat << EOF
  Usage: package_check.sh [OPTION]... PACKAGE_TO_CHECK
 
-    -b, --branch=BRANCH     Specify a branch to check.
+    -b, --branch=BRANCH         Specify a branch to check.
     -a, --arch=ARCH
     -d, --dist=DIST
     -y, --ynh-branch=BRANCH
@@ -22,6 +22,7 @@ print_help() {
                                 images are supposed to be fetch from
                                 devbaseimgs.yunohost.org automatically)
     -S, --storage-dir DIRECTORY Where to store temporary test files like yunohost backups
+    -v, --verbose               Prints the complete debug log to screen
     -h, --help                  Display this help
 
     Pass YNHDEV_BACKEND=incus|lxd to use a specific LXD-compatible backend.
@@ -46,6 +47,7 @@ interactive_on_errors=0
 rebuild=0
 force_stop=0
 storage_dir="${YNH_PACKAGE_CHECK_STORAGE_DIR:-}"
+verbose_log=0
 
 function parse_args() {
 
@@ -65,6 +67,7 @@ function parse_args() {
         arguments[$i]=${arguments[$i]//--rebuild/-r}
         arguments[$i]=${arguments[$i]//--force-stop/-s}
         arguments[$i]=${arguments[$i]//--storage-dir/-s}
+        arguments[$i]=${arguments[$i]//--verbose/-v}
         arguments[$i]=${arguments[$i]//--help/-h}
         getopts_built_arg+=("${arguments[$i]}")
     done
@@ -80,7 +83,7 @@ function parse_args() {
                 # Initialize the index of getopts
                 OPTIND=1
                 # Parse with getopts only if the argument begin by -
-                getopts ":b:Diresh" parameter || true
+                getopts ":b:Direshv" parameter || true
                 case $parameter in
                     b)
                         # --branch=branch-name
@@ -116,6 +119,11 @@ function parse_args() {
                         # --storage-dir
                         storage_dir=$OPTARG
                         shift_value=2
+                        ;;
+                    v)
+                        # --verbose
+                        verbose_log=1
+                        shift_value=1
                         ;;
                     h)
                         # --help
@@ -208,6 +216,9 @@ trap 'exit 2' TERM
 #==========================
 # Main code
 #==========================
+
+# Enable debug log?
+export verbose_log
 
 assert_we_are_connected_to_the_internets
 assert_we_have_all_dependencies

--- a/package_check.sh
+++ b/package_check.sh
@@ -6,6 +6,7 @@ source "./lib/tests_coordination.sh"
 source "./lib/build_base_lxc.sh"
 
 print_help() {
+#STARTHELP
     cat << EOF
  Usage: package_check.sh [OPTION]... PACKAGE_TO_CHECK
 
@@ -28,6 +29,7 @@ print_help() {
     Pass YNHDEV_BACKEND=incus|lxd to use a specific LXD-compatible backend.
 
 EOF
+#ENDHELP
 exit 0
 }
 


### PR DESCRIPTION
This one is very straightforward. In most cases having the debug log in the full_log is plenty enough. However, maybe users want to see the debug log sometimes. I added a `--verbose` flag that allows debug log to be printed to screen, and of course it's still written to the full_log after all.