### PR TITLE
Fixed Grist again as it uses non-/ `base` tag.

### DIFF
--- a/lib/curl_tests.py
+++ b/lib/curl_tests.py
@@ -103,21 +103,25 @@ def curl(
 
     return (return_code, return_content, effective_url)
 
-def validate_and_normalize(domain, base, uri):
-    parsed_domain = urlparse(domain)
+def validate_and_normalize(effective_url, base, uri):
+    parsed_domain = urlparse(effective_url)
 
+    # sometimes assets point to //asset/somethig.css
+    # when parsed 'asset' becomes a domain, strip extra slashes
     while uri.startswith("//"):
         uri = uri[1:]
-    # parse URI as is
-    domain = urljoin(domain, base)
-    domain = urljoin(domain, uri)
 
-    parsed = urlparse(domain)
+    # now, first join base on top of effective_url
+    effective_url = urljoin(effective_url, base)
+    # then potentially relative URI
+    effective_url = urljoin(effective_url, uri)
+
+    # at this point effective_url should contain absolute path to linked content
+    parsed = urlparse(effective_url)
     if parsed.netloc != parsed_domain.netloc:
         # third-party hosting, not good for CI
         return False, ""
 
-    # domain, scheme and path should have been updated at this point
     return True, parsed.geturl()
 
 def test(

--- a/lib/curl_tests.py
+++ b/lib/curl_tests.py
@@ -104,14 +104,20 @@ def curl(
     return (return_code, return_content, effective_url)
 
 def validate_and_normalize(domain, base, uri):
+    # parse URI as is
     parsed = urlparse(uri)
+    # no scheme = relative link, absolutize it anchored on domain
     if parsed.scheme == "":
         parsed = urlparse(f"https://{domain}/" + uri)
     if parsed.netloc != "" and parsed.netloc != domain:
+        # third-party hosting, not good for CI
         return False, ""
+    # prepend base path to path iff base is non-/
     if base != "" and base != "/":
         parsed = parsed._replace(path=f"{base}/{parsed.path}")
-    return True, parsed._replace(netloc=domain)._replace(scheme="https").geturl()
+
+    # domain, scheme and path should have been updated at this point
+    return True, parsed.geturl()
 
 def test(
     base_url,


### PR DESCRIPTION
In #185 I broke previous fix for Grist from #176.
That's because Grist uses `<base>` tag and I disregarded it.

Tested with:
 - NocoDB (relative path to non-root in subdomain)
 - Grist (uses `<base href="/some/location/">` tag)
 -  Piped (uses `<base href="/">`)
 - Element (a standard app on subpath that uses relative linking)