### PR TITLE
Fix usage of `-b`

### DIFF
--- a/package_check.sh
+++ b/package_check.sh
@@ -83,7 +83,7 @@ function parse_args() {
                 case $parameter in
                     b)
                         # --branch=branch-name
-                        gitbranch="-b $OPTARG"
+                        gitbranch="$OPTARG"
                         shift_value=2
                         ;;
                     i)


### PR DESCRIPTION
Just specify the `-b` option once to the git clone command ([it is already passed here](https://github.com/YunoHost/package_check/blob/57bc7703d50d853bd0e3c4805250e30efe837141/lib/common.sh#L362)).