### PR TITLE
Fix is_webapp grep pattern

### DIFF
--- a/lib/parse_tests_toml.py
+++ b/lib/parse_tests_toml.py
@@ -164,7 +164,7 @@ def build_test_list(basedir: Path) -> dict[str, dict[str, Any]]:
 
     is_webapp = (
         os.system(
-            f"grep -q '^ynh_add_nginx_config\|^ynh_nginx_add_config\|^ynh_config_add_nginx' '{str(basedir)}/scripts/install'"
+            f"grep -q '^ynh_add_nginx_config\\|^ynh_nginx_add_config\\|^ynh_config_add_nginx' '{str(basedir)}/scripts/install'"
         )
         == 0
     )


### PR DESCRIPTION
## The problem

I get this warning:
```
[REDACTED]/./lib/parse_tests_toml.py:167: SyntaxWarning: invalid escape sequence '\|'
  f"grep -q '^ynh_add_nginx_config\|^ynh_nginx_add_config\|^ynh_config_add_nginx' '{str(basedir)}/scripts/install'"
Traceback (most recent call last):
```

## The solution

We escape the antislashes, as it is specified in a command wrapped in double-quote