### PR TITLE
Snapshot after running postinstall

### DIFF
--- a/lib/tests_coordination.sh
+++ b/lib/tests_coordination.sh
@@ -100,6 +100,7 @@ TEST_LAUNCHER() {
     local global_start_timer=$starttime
 
     current_test_id=$(basename "$testfile" | cut -d. -f1)
+    current_test_serie=$(jq -r '.test_serie' "$testfile")
     current_test_infos="$TEST_CONTEXT/tests/$current_test_id.json"
     current_test_results="$TEST_CONTEXT/results/$current_test_id.json"
     current_test_log="$TEST_CONTEXT/logs/$current_test_id.log"
@@ -208,8 +209,6 @@ break_before_continue() {
 }
 
 start_test() {
-    local current_test_serie
-    current_test_serie=$(jq -r '.test_serie' "$testfile")
     [[ "$current_test_serie" != "default" ]] \
         && current_test_serie="($current_test_serie) " \
         || current_test_serie=""


### PR DESCRIPTION
postinstall scripts may require long time and can be subject to errors. Indeed, in many case, they are run to add domains and install app dependencies.

They were run several times often right after restauring the initial snapshot.

That's the reason why in this commit we snapshot right after running preinstall and we take advantage of it.