### PR TITLE
curl_tests: Force interface incusbr0 to be used

### DIFF
--- a/lib/curl_tests.py
+++ b/lib/curl_tests.py
@@ -78,6 +78,7 @@ def curl(
             f"{SUBDOMAIN}:443:{LXC_IP}",
         ],
     )  # --resolve
+    c.setopt(c.INTERFACE, 'if!incusbr0') # --interface
     c.setopt(c.HTTPHEADER, [f"Host: {domain}", "X-Requested-With: libcurl"])  # --header
     if use_cookies:
         c.setopt(c.COOKIEFILE, use_cookies)


### PR DESCRIPTION
Tested with success against nextcloud (which is AFAIK the package which makes the most advanced use of curl tests)