### PR TITLE
curl_tests: Redirect any request to the incus container

### DIFF
--- a/lib/curl_tests.py
+++ b/lib/curl_tests.py
@@ -72,10 +72,8 @@ def curl(
     c.setopt(
         c.RESOLVE,
         [
-            f"{DOMAIN}:80:{LXC_IP}",
-            f"{DOMAIN}:443:{LXC_IP}",
-            f"{SUBDOMAIN}:80:{LXC_IP}",
-            f"{SUBDOMAIN}:443:{LXC_IP}",
+            f"*:80:{LXC_IP}",
+            f"*:443:{LXC_IP}",
         ],
     )  # --resolve
     c.setopt(c.INTERFACE, "if!incusbr0")  # --interface


### PR DESCRIPTION
## Problem

When creating custom domains in the tests, the curl tests don't recognize them as being part of the incus container and does not request it.

## Solution

Use wildcard to redirect all the domains to the incus container. Quoting [this documentation](https://curl.se/libcurl/c/CURLOPT_RESOLVE.html):
> Specify the host as a single asterisk (*) to match all names. This wildcard is resolved last so any resolve with a specific host and port number is given priority. 