### PR TITLE
Fixes

### DIFF
--- a/lib/build_base_lxc.sh
+++ b/lib/build_base_lxc.sh
@@ -53,7 +53,6 @@ function rebuild_base_lxc()
     $IN_LXC rm -f /etc/cron.daily/apt-compat
     $IN_LXC cp /bin/true /usr/lib/apt/apt.systemd.daily
 
-    # Disable password strength check
     $IN_LXC yunohost tools postinstall --domain "$DOMAIN" --username "$YUNO_ADMIN" --fullname "$YUNO_ADMIN_FULLNAME" --password "$YUNO_PWD" --i-have-read-terms-of-services --force-diskspace
 
     $IN_LXC yunohost settings set security.password.admin_strength -v -1

--- a/lib/build_base_lxc.sh
+++ b/lib/build_base_lxc.sh
@@ -54,15 +54,13 @@ function rebuild_base_lxc()
     $IN_LXC cp /bin/true /usr/lib/apt/apt.systemd.daily
 
     # Disable password strength check
-    $IN_LXC yunohost tools postinstall --domain "$DOMAIN" --password "$YUNO_PWD" --force-password
+    $IN_LXC yunohost tools postinstall --domain "$DOMAIN" --username "$YUNO_ADMIN" --fullname "$YUNO_ADMIN_FULLNAME" --password "$YUNO_PWD" --i-have-read-terms-of-services --force-diskspace
 
-    $IN_LXC yunohost settings set security.password.admin.strength -v -1
-    $IN_LXC yunohost settings set security.password.user.strength -v -1
+    $IN_LXC yunohost settings set security.password.admin_strength -v -1
+    $IN_LXC yunohost settings set security.password.user_strength -v -1
 
     $IN_LXC yunohost domain add "$SUBDOMAIN"
-    TEST_USER_DISPLAY=${TEST_USER//"_"/""}
-    $IN_LXC yunohost user create "$TEST_USER" --firstname "$TEST_USER_DISPLAY" \
-        --mail "$TEST_USER@$DOMAIN" --lastname "$TEST_USER_DISPLAY" --password "$YUNO_PWD"
+    $IN_LXC yunohost user create "$TEST_USER" --fullname "$TEST_USER_FULLNAME" --domain "$DOMAIN" --password "$YUNO_PWD"
 
     $IN_LXC yunohost --version
 

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -2,10 +2,13 @@
 # shellcheck disable=SC2034,SC2155
 
 # YunoHost install parameters
-YUNO_PWD="admin"
+YUNO_ADMIN="ciadmin"
+YUNO_ADMIN_FULLNAME="CI admin"
+YUNO_PWD="SuperSecretCIPassw0rd"
 DOMAIN="domain.tld"
 SUBDOMAIN="sub.$DOMAIN"
 TEST_USER="package_checker"
+TEST_USER_FULLNAME="Package Checker"
 
 # shellcheck disable=SC1091
 [[ -e "./config" ]] && source "./config"
@@ -18,7 +21,7 @@ DEFAULT_PHP_VERSION=${DEFAULT_PHP_VERSION:-7.4}
 YNH_BRANCH=${YNH_BRANCH:-stable}
 
 WORKER_ID=${WORKER_ID:-0}
-LXC_BASE="yunohost/$DIST-$YNH_BRANCH/appci"
+LXC_BASE="yunohost-$DIST-$YNH_BRANCH-appci"
 LXC_NAME="ynh-appci-$DIST-$ARCH-$YNH_BRANCH-test-${WORKER_ID}"
 
 readonly lock_file="./pcheck-${WORKER_ID}.lock"

--- a/lib/tests.sh
+++ b/lib/tests.sh
@@ -581,7 +581,7 @@ TEST_BACKUP_RESTORE() {
         }
 
         # Grab the backup archive into the LXC container, and keep a copy
-        $lxc file pull -r "$LXC_NAME/home/yunohost.backup/archives" "$TEST_CONTEXT/ynh_backups"
+        $lxc file pull -r "$LXC_NAME/home/yunohost.backup/archives" "$TEST_CONTEXT/ynh_backups/"
 
         # RESTORE
         # Try the restore process in 2 times, first after removing the app, second after a restore of the container.


### PR DESCRIPTION
1. New incus version(?) forbids us to use slashes in instance names
2. I don't know how the post-install was even working on the latest YunoHost 12.x