### PR TITLE
fix password on sso

### DIFF
--- a/lib/tests.sh
+++ b/lib/tests.sh
@@ -298,7 +298,7 @@ _VALIDATE_THAT_APP_CAN_BE_ACCESSED() {
         DOMAIN="$DOMAIN" \
         SUBDOMAIN="$SUBDOMAIN" \
         USER="$TEST_USER" \
-        PASSWORD="SomeSuperStrongPassword" \
+        PASSWORD="$YUNO_PWD" \
         LXC_IP="$LXC_IP" \
         BASE_URL="https://$domain_to_check$path_to_check" \
         python3 lib/curl_tests.py < "$TEST_CONTEXT/curl_tests.toml" | tee -a "$full_log"


### PR DESCRIPTION
Since latest changes, the hardcoded password for `logged_on_sso` doesn’t seem to work anymore.

So use the password set via environment variable.

Tested and tests pass now