### PR TITLE
Allow to use admin user for curl test with SSO

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,7 @@ test_format = 1.0
 
     admin.path = "/settings/admin"
     admin.logged_on_sso = true
+    admin.logged_as_admin = true
     admin.expect_title = "Paramètres d'administration - Nextcloud"
 
     asset.path = "/core/img/logo/logo.svg"

--- a/lib/curl_tests.py
+++ b/lib/curl_tests.py
@@ -13,6 +13,7 @@ DOMAIN = os.environ["DOMAIN"]
 DIST = os.environ["DIST"]
 SUBDOMAIN = os.environ["SUBDOMAIN"]
 USER = os.environ["USER"]
+ADMIN_USER = os.environ["YUNO_ADMIN"]
 PASSWORD = os.environ["PASSWORD"]
 LXC_IP = os.environ["LXC_IP"]
 BASE_URL = os.environ["BASE_URL"].rstrip("/")
@@ -22,6 +23,7 @@ DEFAULTS = {
     "base_url": BASE_URL,
     "path": "/",
     "logged_on_sso": False,
+    "logged_as_admin": False,
     "expect_title": None,
     "expect_content": None,
     "expect_return_code": 200,
@@ -40,6 +42,7 @@ DEFAULTS = {
 #
 # admin.path = "/settings/admin"
 # admin.logged_on_sso = true
+# admin.logged_as_admin = true
 # admin.expect_title = "Paramètres d'administration - Nextcloud"
 #
 # asset.path = "/core/img/logo/logo.svg"
@@ -125,6 +128,7 @@ def test(
     path,
     post=None,
     logged_on_sso=False,
+    logged_as_admin=False,
     expect_return_code=200,
     expect_content=None,
     expect_title=None,
@@ -138,7 +142,7 @@ def test(
         code, content, _ = curl(
             f"https://{domain}/yunohost/portalapi/login",
             save_cookies=cookies,
-            post={"credentials": f"{USER}:{PASSWORD}"},
+            post={"credentials": f"{ADMIN_USER if logged_as_admin else USER}:{PASSWORD}"},
         )
         assert (
             code == 200 and content == "Logged in"
@@ -272,9 +276,10 @@ def run(tests):
         full_params.update(params)
         for key, value in full_params.items():
             if isinstance(value, str):
-                full_params[key] = value.replace("__USER__", USER).replace(
-                    "__DOMAIN__", APP_DOMAIN
-                )
+                full_params[key] = value \
+                    .replace("__USER__", USER) \
+                    .replace("__ADMIN_USER__", ADMIN_USER) \
+                    .replace("__DOMAIN__", APP_DOMAIN)
 
         results[name] = test(**full_params)
         display_result(results[name])

--- a/lib/tests.sh
+++ b/lib/tests.sh
@@ -298,6 +298,7 @@ _VALIDATE_THAT_APP_CAN_BE_ACCESSED() {
         DOMAIN="$DOMAIN" \
         SUBDOMAIN="$SUBDOMAIN" \
         USER="$TEST_USER" \
+        YUNO_ADMIN="$YUNO_ADMIN" \
         PASSWORD="$YUNO_PWD" \
         LXC_IP="$LXC_IP" \
         BASE_URL="https://$domain_to_check$path_to_check" \


### PR DESCRIPTION
# Problem

Test broken, like with forgejo https://github.com/YunoHost-Apps/forgejo_ynh/pull/193 because now there are not any more a way to run curl test with admin rights

# Solution

 provide an admin user for curl tests.

# state

Tested with forgejo on https://github.com/YunoHost-Apps/forgejo_ynh/pull/193, seem working as expected.